### PR TITLE
Fix rounding error for step_x, step_y on save/reload

### DIFF
--- a/rompar/rompar.py
+++ b/rompar/rompar.py
@@ -70,9 +70,13 @@ class Rompar(object):
                                                 len(self._grid_points_y)))
 
             if len(self._grid_points_x) > 1:
-                self.step_x = self._grid_points_x[1] - self._grid_points_x[0]
+                self.step_x = (self._grid_points_x[self.group_cols - 1] -
+                               self._grid_points_x[0]) / \
+                              (self.group_cols - 1)
             if len(self._grid_points_y) > 1:
-                self.step_y = self._grid_points_y[1] - self._grid_points_y[0]
+                self.step_y = (self._grid_points_y[self.group_rows - 1] -
+                               self._grid_points_y[0]) / \
+                              (self.group_rows - 1)
             if not self.config.default_radius:
                 if self.step_x:
                     self.config.radius = int(self.step_x / 3)


### PR DESCRIPTION
rompar currently determines the step_x,step_y setting by copying the distance between the first
two rows/columns. In my use case, the row/column size was not integer and this resulted in not being able to correctly add new blocks after a reload from disk. My proposed (and implemented) fix is simple: compute the average step over the first block instead of looking just at the first row/column.
A future addition could be saving the step_x,step_y separately but this would break compatibility.